### PR TITLE
Minor improvements at the crap helper class (no pun intended)

### DIFF
--- a/src/CrapHelper.php
+++ b/src/CrapHelper.php
@@ -125,7 +125,7 @@ class CrapHelper
      */
     public function validateAlias($alias)
     {
-        return preg_match("{^[a-z0-9_.-]+$}", $alias) ? true : false;
+        return (bool) preg_match("{^[a-z0-9_.-]+$}", $alias);
     }
 
     /**

--- a/src/CrapHelper.php
+++ b/src/CrapHelper.php
@@ -169,12 +169,9 @@ class CrapHelper
      */
     public function parseArguments(array $arguments, $excludeVersions = false)
     {
-        $require = [];
-
-        foreach ($arguments as $arg) {
+        return array_map(function ($arg) use ($excludeVersions) {
             if ($this->validatePackage($arg)) {
-                $require[] = $arg;
-                continue;
+                return $arg;
             }
 
             list($alias, $argVersion) = $this->parsePackageToArray($arg);
@@ -188,13 +185,11 @@ class CrapHelper
             $version = null;
 
             if (!$excludeVersions) {
-                $version = !is_null($argVersion) ? $argVersion : $packageVersion;
+                $version = $argVersion ?: $packageVersion;
             }
 
-            $require[] = ($version === null) ? $package : sprintf("%s:%s", $package, $version);
-        }
-
-        return $require;
+            return (is_null($version)) ? $package : sprintf('%s:%s', $package, $version);
+        }, $arguments);
     }
 
     /**


### PR DESCRIPTION
## Description

1. Converting to **boolean** the return of the method **validateAlias**, avoiding the ternary condition.
2. Using **array_map** function to parse the arguments, that way we get rid of the **foreach** and the **$require**.

## Motivation and context

Since the **parseArguments** method is mutating an array of arguments, I believe that the **array_map** function is the perfect solution for this case.

Thanks for making such a cool library :D